### PR TITLE
Change package owner name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@tubitv/adrise-connect-datadog",
+	"name": "@adRise/adrise-connect-datadog",
 	"version": "0.0.8",
 	"description": "Datadog middleware for Connect JS / Express",
 	"main": "index.js",


### PR DESCRIPTION
This renames the package in order to utilize github package registry, which requires the package owner to be the same as the repository owner.
Existing tubitv packages will still exist at http://npm.adrise.tv/ so long as that server is maintained, but future packages can be published to the github package registry. (The first one should be visible in this repository already).